### PR TITLE
add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "^5.5|^6|^7",
+        "illuminate/support": "^5.5|^6|^7|^8",
         "studio-42/elfinder": "~2.1.49",
         "barryvdh/elfinder-flysystem-driver": "^0.2",
         "league/flysystem": "^1.0",


### PR DESCRIPTION
Good news! it looks like all we need to do to support Laravel 8 is to bump the version 🥳 

I haven't tested all features, but I have tested the most important ones, and they work just fine:

![2020-09-08 10 07 20](https://user-images.githubusercontent.com/1032474/92487465-42326a00-f1bb-11ea-9de4-e67aa7d72e86.gif)

